### PR TITLE
Make MetaBroker more Meta

### DIFF
--- a/src/broker/meta_broker.py
+++ b/src/broker/meta_broker.py
@@ -1,13 +1,26 @@
 from hypothesis.stateful import GenericStateMachine
 from hypothesis.strategies import tuples, sampled_from, just, integers,one_of
-from collections import namedtuple
-
+from random import Random
 from brokers import timer,file_system,network,power
+
+from node import Node
 
 class MetaBroker(GenericStateMachine):
     def __init__(self):
-        self.action_queue = []
+        """
+        The MetaBroker is in charge of setting up, testing, and coordinating work between
+        nodes and their co/effects.
+
+        For now, this is where cluster initialization happens.
+        """
+        conf = {'node_list':set(range(5)),'heartbeat_freq':100,'election_timeout_window':(150,300)}
         self.nodes = {}
+        for nid in range(5):
+            random_seed = Random()
+            random_seed.seed(nid)
+            self.nodes[nid] = Node(nid,conf,random_seed,self)
+
+        self.action_queue = []
         self.timer_broker = timer.TimerBroker(nodes)
         self.file_broker = file_system.FileBroker(nodes)
         self.network_broker = network.NetworkBroker(nodes)
@@ -29,3 +42,21 @@ class MetaBroker(GenericStateMachine):
             self.network_broker.execute_step(action)
         elif broker == 'Power':
             self.power_broker.execute_step(action)
+
+
+    # From File Broker
+    def read_file(self,node_id,file_name):
+        self.file_broker.read_file(node_id,file_name)
+
+    def write_file(self,node_id,file_name,data):
+        self.file_broker.write_file(node_id,file_name,data)
+
+
+    # From Timer Broker
+    def add_timer(self,node_id,time_out):
+        self.timer_broker.add_timer(node_id,time_out)
+
+
+    # From Network Broker
+    def send_to(self,sender,to,data):
+        self.network_broker.send_to(sender,to,data)

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,18 @@
+# Necessary steps to implement RAFT
+[ ] Update TimerBroker to recognize proper timer delays
+[ ] Verify operation of timer firing
+[ ] Add happy path operation to MetaBroker
+[ ] Implement Leader Election
+[ ] Verify Leader Election properties
+1. Manual tests with some cases that work
+2. Only one leader in a given term
+3. When a majority of nodes are up, there should eventually be a leader
+[ ] Log Replication
+[ ] Verify Log Replication
+1. Once a an entry is committed, it's never deleted
+2. Logs are identical across nodes once committed
+[ ] State machine counter
+[ ] Configuration changes
+[ ] Verify Config changes
+1. Manual test cases that should work
+2. Generative testing that should work


### PR DESCRIPTION
MetaBroker will now transparently dispatch to the sub-brokers based on
their public(node facing) api. It will also init the nodes to start
things up.