### PR TITLE
Fix leader election with ReceiveDrop

### DIFF
--- a/src/world_broker.py
+++ b/src/world_broker.py
@@ -23,7 +23,7 @@ class WorldBroker(GenericStateMachine):
     "TODO"
     def __init__(self):
         # Run/Test Settings
-        self.catastrophy_level = 0
+        self.catastrophy_level = 1
         self.time_window_length = 700
         self.event_window_length = 150
         self.message_send_delay = 6
@@ -77,7 +77,11 @@ class WorldBroker(GenericStateMachine):
         for entry in self.test_logging:
             if entry['log_type'] == 'change_type':
                 print(
-                    "{}: {}->{}".format(entry['term'], entry['node_type'], entry['to_type']))
+                    "Term #{}, Node #{}: {}->{}".format(entry['term'], entry['node'], entry['node_type'], entry['to_type']))
+            elif entry['log_type'] == 'update_term':
+                print("Node #{} increased term to {}".format(entry['node'], entry['term']))
+            elif entry['log_type'] == 'voted_for':
+                print("Node #{} voted for node #{}".format(entry['node'], entry['voted_for']))
 
     def get_node_for_testing(self, node_id):
         '''Return the canonical version of a node given its node_id.


### PR DESCRIPTION
There were two problems causing leader election to fail during ReceiveDrop
events. The first was that followers did not keep track of who the voted for,
and thus could vote for more than one candidate. The second was that followers
would try to directly transition into leaders when they got a
RequestVoteResponse - thus previous candidates who had heard from a leader or a
higher term candidate and transitioned to a follower when a RequestVoteResponse
was still in the process of being sent were able to convert into a leader once
they received enough (stale) votes.

This commit also adds more logging information to the broker log. I'm not 100%
sure how this is meant to be used, so please correct me if I should be using it
differently.

Closes #18 