### PR TITLE
Add leader history check at every increment, not every step.

### DIFF
--- a/src/world_broker.py
+++ b/src/world_broker.py
@@ -199,8 +199,9 @@ class WorldBroker(GenericStateMachine):
                     if adjusted_time > self.time_broker['node_timers'][node]:
                         self.power_broker['nodes'][node].timer_trip()
             self.current_time += 1
+            self.check_leader_history()
 
-        self.check_leader_history()
+
 
     def teardown(self):
         "TODO"


### PR DESCRIPTION
This fixes a bug where we get a false failure when a leader is elected and then goes away within one time step.