### PR TITLE
Allow hypothesis to generate random delays

### DIFF
--- a/src/world_broker.py
+++ b/src/world_broker.py
@@ -4,7 +4,7 @@ The main emulator of the world, and bootstrapper of tests.
 
 import unittest
 import collections
-from random import randint, Random
+from random import Random
 from heapq import heappush, heappop
 
 

--- a/src/world_broker.py
+++ b/src/world_broker.py
@@ -170,16 +170,19 @@ class WorldBroker(GenericStateMachine):
 
     def steps(self):
         "TODO"
-        return lists(self.gen_adverse_event(), max_size=self.catastrophy_level)
+        delays = just([])
+        adverse_events = lists(self.gen_adverse_event(), max_size=self.catastrophy_level)
+        randomness = {'delays': just([]), 'adverse_events': adverse_events}
+        return fixed_dictionaries(randomness)
 
     # pylint: disable=arguments-differ
-    def execute_step(self, adverse_events):
+    def execute_step(self, randomness):
         """
         steps is a list of steps (possibly len() 0)
         """
 
         # Add a set of events to the action_queue, an the corresponding events to heal it
-        for event in adverse_events:
+        for event in randomness['adverse_events']:
             reversals = event.backout()
             heappush(self.action_queue, event)
             for rev in reversals:

--- a/src/world_broker.py
+++ b/src/world_broker.py
@@ -27,7 +27,7 @@ class WorldBroker(GenericStateMachine):
         self.catastrophy_level = 1
         self.time_window_length = 700
         self.event_window_length = 150
-        self.message_send_delay = 6
+        self.message_send_delay = 10
 
         self.delays = []
         self.delay_index = 0
@@ -253,7 +253,7 @@ class WorldBroker(GenericStateMachine):
         "TODO"
         assert origin != destination
 
-        delay = self.message_send_delay
+        delay = 1
         if self.delays:
             delay = self.delays[self.delay_index]
             self.delay_index = (self.delay_index + 1) % len(self.delays)


### PR DESCRIPTION
I think that, with the current code, it's very unlikely (maybe impossible) to have nodes vote for different leaders. Randomizing the transport delay should fix that.